### PR TITLE
Corrected skipped and repeated indexes in main.cpp

### DIFF
--- a/HTC-Vive-SRanipal/SRanipal_LSL/main.cpp
+++ b/HTC-Vive-SRanipal/SRanipal_LSL/main.cpp
@@ -113,15 +113,15 @@ void streaming() {
 				sample[16] = eye_opennessL;
 				sample[17] = eye_opennessR;
 
-				sample[19] = pupilLSensorPos[0];
-				sample[20] = pupilLSensorPos[1];
-				sample[21] = pupilLSensorPos[2];
-				sample[22] = pupilRSensorPos[0];
-				sample[23] = pupilRSensorPos[1];
+				sample[18] = pupilLSensorPos[0];
+				sample[19] = pupilLSensorPos[1];
+				sample[20] = pupilLSensorPos[2];
+				sample[21] = pupilRSensorPos[0];
+				sample[22] = pupilRSensorPos[1];
 				sample[23] = pupilRSensorPos[2];
 
-				sample[25] = convergence_distance_mm;
-				sample[26] = convergence_distance_validity;
+				sample[24] = convergence_distance_mm;
+				sample[25] = convergence_distance_validity;
 
 
 


### PR DESCRIPTION
Array indexes 18 and 24 were skipped, and index 23 was repeated for the `sample` array when assigning the eye-tracking data between lines 114 and 124. As a result, the sample array had an out-of-bound index and the pupil position data was getting overwritten. This commit should fix these issues.